### PR TITLE
Add system_instruction support and split context into before/after

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -510,15 +510,22 @@ fn save_gemini_settings(
 async fn translate_with_gemini(
     app: tauri::AppHandle,
     text: String,
-    context: String,
+    context_before: String,
+    context_after: String,
     model_override: Option<String>,
 ) -> Result<gemini::TranslationResponse, String> {
     let gemini_settings = settings::get_gemini_settings(&app).map_err(|e| e.into_tauri_error())?;
     let model = model_override.as_deref().unwrap_or(&gemini_settings.model);
 
-    gemini::translate_text(&gemini_settings.api_key, model, &text, &context)
-        .await
-        .map_err(|e| e.into_tauri_error())
+    gemini::translate_text(
+        &gemini_settings.api_key,
+        model,
+        &text,
+        &context_before,
+        &context_after,
+    )
+    .await
+    .map_err(|e| e.into_tauri_error())
 }
 
 /// Get explanation of text (returns summary + explanation points)
@@ -526,7 +533,8 @@ async fn translate_with_gemini(
 async fn explain_directly(
     app: tauri::AppHandle,
     text: String,
-    context: String,
+    context_before: String,
+    context_after: String,
     model_override: Option<String>,
 ) -> Result<gemini::ExplanationResponse, String> {
     let gemini_settings = settings::get_gemini_settings(&app).map_err(|e| e.into_tauri_error())?;
@@ -534,9 +542,15 @@ async fn explain_directly(
         .as_deref()
         .unwrap_or(&gemini_settings.explanation_model);
 
-    gemini::explain_text(&gemini_settings.api_key, model, &text, &context)
-        .await
-        .map_err(|e| e.into_tauri_error())
+    gemini::explain_text(
+        &gemini_settings.api_key,
+        model,
+        &text,
+        &context_before,
+        &context_after,
+    )
+    .await
+    .map_err(|e| e.into_tauri_error())
 }
 
 // ============================================================================

--- a/src/app/translation/page.tsx
+++ b/src/app/translation/page.tsx
@@ -11,7 +11,8 @@ import { explainDirectly, getGeminiSettings, GEMINI_MODELS } from '@/lib/setting
 
 interface TranslationData {
   selectedText: string;
-  context: string;
+  contextBefore: string;
+  contextAfter: string;
   translationResponse: TranslationResponse;
   autoExplain: boolean;
 }
@@ -151,7 +152,8 @@ function TranslationContent() {
       try {
         const result = await explainDirectly(
           data.selectedText,
-          data.context,
+          data.contextBefore,
+          data.contextAfter,
           geminiSettings.explanationModel
         );
         setExplanationSummary(result.summary);
@@ -199,10 +201,19 @@ function TranslationContent() {
           {showContext ? <ChevronUp className="w-3 h-3" /> : <ChevronDown className="w-3 h-3" />}
         </button>
         {showContext && (
-          <div className="px-3 pb-2">
-            <p className="text-xs text-text-tertiary font-mono whitespace-pre-wrap max-h-[150px] overflow-y-auto bg-bg-secondary p-2 rounded">
-              {data.context || '(no context)'}
-            </p>
+          <div className="px-3 pb-2 space-y-2">
+            <div>
+              <span className="text-xs text-text-tertiary">Before:</span>
+              <p className="text-xs text-text-tertiary font-mono whitespace-pre-wrap max-h-[75px] overflow-y-auto bg-bg-secondary p-2 rounded">
+                {data.contextBefore || '(no context)'}
+              </p>
+            </div>
+            <div>
+              <span className="text-xs text-text-tertiary">After:</span>
+              <p className="text-xs text-text-tertiary font-mono whitespace-pre-wrap max-h-[75px] overflow-y-auto bg-bg-secondary p-2 rounded">
+                {data.contextAfter || '(no context)'}
+              </p>
+            </div>
           </div>
         )}
       </div>

--- a/src/components/TranslationPopup.tsx
+++ b/src/components/TranslationPopup.tsx
@@ -231,7 +231,8 @@ export default function TranslationPopup({
           // Direct explanation mode - skip translation, get explanation only
           const result = await explainDirectly(
             selection.selectedText,
-            selection.context,
+            selection.contextBefore,
+            selection.contextAfter,
             settings.explanationModel
           );
 
@@ -247,7 +248,8 @@ export default function TranslationPopup({
           // Translation mode
           const result = await translateWithGemini(
             selection.selectedText,
-            selection.context,
+            selection.contextBefore,
+            selection.contextAfter,
             settings.model
           );
 
@@ -286,7 +288,8 @@ export default function TranslationPopup({
       try {
         const result = await explainDirectly(
           selection.selectedText,
-          selection.context,
+          selection.contextBefore,
+          selection.contextAfter,
           geminiSettings.explanationModel
         );
 
@@ -299,7 +302,7 @@ export default function TranslationPopup({
         setIsExplaining(false);
       }
     }, 0);
-  }, [translationResponse, isExplaining, geminiSettings, selection.selectedText, selection.context]);
+  }, [translationResponse, isExplaining, geminiSettings, selection.selectedText, selection.contextBefore, selection.contextAfter]);
 
   // Note: Auto-trigger explanation is no longer needed
   // In autoExplain mode, we call explainDirectly in the initial useEffect
@@ -330,7 +333,8 @@ export default function TranslationPopup({
           unlisten();
           await emitTo(windowLabel, 'translation-data', {
             selectedText: selection.selectedText,
-            context: selection.context,
+            contextBefore: selection.contextBefore,
+            contextAfter: selection.contextAfter,
             translationResponse,
             autoExplain,
           });
@@ -355,7 +359,7 @@ export default function TranslationPopup({
     } catch (e) {
       console.error('Failed to open translation window:', e);
     }
-  }, [translationResponse, selection.selectedText, selection.context, autoExplain, onClose]);
+  }, [translationResponse, selection.selectedText, selection.contextBefore, selection.contextAfter, autoExplain, onClose]);
 
   return (
     <div
@@ -407,10 +411,19 @@ export default function TranslationPopup({
           {showContext ? <ChevronUp className="w-3 h-3" /> : <ChevronDown className="w-3 h-3" />}
         </button>
         {showContext && (
-          <div className="px-3 pb-2">
-            <p className="text-xs text-text-tertiary font-mono whitespace-pre-wrap max-h-[150px] overflow-y-auto bg-bg-primary p-2 rounded">
-              {selection.context || '(no context)'}
-            </p>
+          <div className="px-3 pb-2 space-y-2">
+            <div>
+              <span className="text-xs text-text-tertiary">Before:</span>
+              <p className="text-xs text-text-tertiary font-mono whitespace-pre-wrap max-h-[75px] overflow-y-auto bg-bg-primary p-2 rounded">
+                {selection.contextBefore || '(no context)'}
+              </p>
+            </div>
+            <div>
+              <span className="text-xs text-text-tertiary">After:</span>
+              <p className="text-xs text-text-tertiary font-mono whitespace-pre-wrap max-h-[75px] overflow-y-auto bg-bg-primary p-2 rounded">
+                {selection.contextAfter || '(no context)'}
+              </p>
+            </div>
           </div>
         )}
       </div>

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -93,12 +93,14 @@ export async function saveGeminiSettings(settings: GeminiSettings): Promise<void
  */
 export async function translateWithGemini(
   text: string,
-  context: string,
+  contextBefore: string,
+  contextAfter: string,
   modelOverride?: string
 ): Promise<TranslationResponse> {
   const result = await invoke<TranslationResponse>('translate_with_gemini', {
     text,
-    context,
+    contextBefore,
+    contextAfter,
     modelOverride: modelOverride ?? null,
   });
   return result;
@@ -110,12 +112,14 @@ export async function translateWithGemini(
  */
 export async function explainDirectly(
   text: string,
-  context: string,
+  contextBefore: string,
+  contextAfter: string,
   modelOverride?: string
 ): Promise<ExplanationResponse> {
   const result = await invoke<ExplanationResponse>('explain_directly', {
     text,
-    context,
+    contextBefore,
+    contextAfter,
     modelOverride: modelOverride ?? null,
   });
   return result;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -327,7 +327,8 @@ export interface ExplanationResponse {
  */
 export interface TextSelection {
   selectedText: string;
-  context: string;
+  contextBefore: string;
+  contextAfter: string;
   isWord: boolean;
   position: { x: number; y: number };
   contextLoading?: boolean;


### PR DESCRIPTION
Gemini API changes:
- Add system_instruction field to GeminiRequest for behavioral guidelines
- Split prompts into SYSTEM_INSTRUCTION (rules) and USER_PROMPT (data)
- Replace single context with context_before and context_after for accurate original sentence extraction when translating single words

Frontend changes:
- Update TextSelection type: context -> contextBefore + contextAfter
- Update useTextSelection hook to return separate context parts
- Update TranslationPopup and translation page to display split context
- Update settings.ts API functions for new parameter structure

This improves translation accuracy by clearly showing the selected word's position between context_before and context_after, helping the model extract the correct original sentence even when the same word appears multiple times in the surrounding text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)