### PR TITLE
Add SecureString type to prevent accidental logging of secrets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -459,3 +459,29 @@ Both must pass before merge. Build artifacts are created locally via `npm run ta
 - **Tauri Permissions:** File system access and window creation require capabilities in `src-tauri/capabilities/default.json`
 - **Japanese Character Support:** The PDF metadata decoder handles multiple Japanese encodings specifically
 - **Session Restore Timing:** Session restoration uses `restoreInProgressRef` to avoid race conditions with multiple async loads
+
+## Development Guidelines
+
+### Dependency Versions
+
+When adding or updating dependencies, always use the latest stable version:
+
+- **Check latest versions** before adding new dependencies (crates.io for Rust, npmjs.com for Node.js)
+- **Specify minor version** at minimum (e.g., `"1.8"` not `"1"`) to ensure reproducible builds
+- **Avoid outdated versions** - if a major version exists (e.g., v2.x), don't use v1.x unless there's a specific reason
+
+### Secure String Handling
+
+Sensitive data (API keys, tokens, secrets) must use `SecureString` type (`src-tauri/src/secure_string.rs`):
+
+- `SecureString` hides values in `Debug`/`Display` output (shows `SecureString(****)`)
+- Use `.expose()` only when the actual value is needed (e.g., sending to an API)
+- Memory is zeroed on drop via `zeroize` crate
+
+```rust
+// Good: Value hidden in logs
+eprintln!("{:?}", settings);  // GeminiSettings { api_key: SecureString(****), ... }
+
+// When you need the actual value
+let key = settings.api_key.expose();
+```

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -32,6 +32,7 @@ base64 = "0.22"
 anyhow = "1.0.100"
 thiserror = "2.0.17"
 keyring = "3"
+zeroize = { version = "1.8", features = ["derive"] }
 
 # Google Drive integration
 reqwest = { version = "0.12", features = ["json", "stream", "blocking"] }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -22,6 +22,7 @@ pub mod menu;
 pub mod oauth;
 pub mod pdf;
 pub mod secrets;
+pub mod secure_string;
 pub mod session;
 pub mod settings;
 pub mod types;
@@ -149,7 +150,7 @@ fn save_oauth_credentials(
         &app,
         &oauth::OAuthCredentials {
             client_id,
-            client_secret,
+            client_secret: client_secret.into(), // Convert to SecureString
         },
     )
     .map_err(|e| e.into_tauri_error())
@@ -518,7 +519,7 @@ async fn translate_with_gemini(
     let model = model_override.as_deref().unwrap_or(&gemini_settings.model);
 
     gemini::translate_text(
-        &gemini_settings.api_key,
+        gemini_settings.api_key.expose(), // SecureString -> &str
         model,
         &text,
         &context_before,
@@ -543,7 +544,7 @@ async fn explain_directly(
         .unwrap_or(&gemini_settings.explanation_model);
 
     gemini::explain_text(
-        &gemini_settings.api_key,
+        gemini_settings.api_key.expose(), // SecureString -> &str
         model,
         &text,
         &context_before,

--- a/src-tauri/src/secure_string.rs
+++ b/src-tauri/src/secure_string.rs
@@ -1,0 +1,159 @@
+//! Secure string type that prevents accidental logging of secrets
+//!
+//! This module provides a wrapper type for sensitive strings that:
+//! - Hides the value in Debug and Display output
+//! - Requires explicit `.expose()` call to access the inner value
+//! - Zeros memory on drop (via zeroize crate)
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::fmt;
+use zeroize::{Zeroize, ZeroizeOnDrop};
+
+/// A secure string wrapper that prevents accidental logging of secrets.
+///
+/// # Example
+/// ```
+/// use pedaru_lib::secure_string::SecureString;
+///
+/// let secret = SecureString::new("my-api-key");
+/// println!("{:?}", secret);  // Prints: SecureString(****)
+/// let value = secret.expose();  // Explicit access required
+/// ```
+#[derive(Clone, Default, Zeroize, ZeroizeOnDrop)]
+pub struct SecureString {
+    inner: String,
+}
+
+impl SecureString {
+    /// Create a new SecureString from a string value
+    pub fn new<S: Into<String>>(value: S) -> Self {
+        Self {
+            inner: value.into(),
+        }
+    }
+
+    /// Expose the inner secret value.
+    ///
+    /// Use this method only when you need to actually use the secret,
+    /// such as sending it to an API or storing it in a secure location.
+    pub fn expose(&self) -> &str {
+        &self.inner
+    }
+
+    /// Check if the secret is empty
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    /// Get the length of the secret
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+}
+
+impl fmt::Debug for SecureString {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "SecureString(****)")
+    }
+}
+
+impl fmt::Display for SecureString {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "****")
+    }
+}
+
+impl From<String> for SecureString {
+    fn from(s: String) -> Self {
+        Self::new(s)
+    }
+}
+
+impl From<&str> for SecureString {
+    fn from(s: &str) -> Self {
+        Self::new(s)
+    }
+}
+
+impl PartialEq for SecureString {
+    fn eq(&self, other: &Self) -> bool {
+        self.inner == other.inner
+    }
+}
+
+impl Eq for SecureString {}
+
+// Serialize: We need this for storing in keychain as JSON
+// The actual value is serialized, but only to secure storage
+impl Serialize for SecureString {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.inner.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for SecureString {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Ok(SecureString::new(s))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_debug_hides_value() {
+        let secret = SecureString::new("my-secret-api-key");
+        let debug_output = format!("{:?}", secret);
+        assert_eq!(debug_output, "SecureString(****)");
+        assert!(!debug_output.contains("my-secret-api-key"));
+    }
+
+    #[test]
+    fn test_display_hides_value() {
+        let secret = SecureString::new("my-secret-api-key");
+        let display_output = format!("{}", secret);
+        assert_eq!(display_output, "****");
+        assert!(!display_output.contains("my-secret-api-key"));
+    }
+
+    #[test]
+    fn test_expose_returns_value() {
+        let secret = SecureString::new("my-secret-api-key");
+        assert_eq!(secret.expose(), "my-secret-api-key");
+    }
+
+    #[test]
+    fn test_is_empty() {
+        let empty = SecureString::new("");
+        let non_empty = SecureString::new("value");
+        assert!(empty.is_empty());
+        assert!(!non_empty.is_empty());
+    }
+
+    #[test]
+    fn test_serialization() {
+        let secret = SecureString::new("test-value");
+        let json = serde_json::to_string(&secret).unwrap();
+        assert_eq!(json, "\"test-value\"");
+
+        let deserialized: SecureString = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.expose(), "test-value");
+    }
+
+    #[test]
+    fn test_equality() {
+        let a = SecureString::new("same");
+        let b = SecureString::new("same");
+        let c = SecureString::new("different");
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+    }
+}


### PR DESCRIPTION
- Introduce SecureString wrapper that hides values in Debug/Display output
- Update secrets.rs, settings.rs, oauth.rs to use SecureString for sensitive data
- Add zeroize crate (v1.8) to zero memory on drop
- Document SecureString usage and dependency version guidelines in CLAUDE.md

SecureString shows "SecureString(****)" in logs instead of actual values. Use .expose() only when the actual value is needed (e.g., API calls).