### PR TITLE
fix(linux): Disable window dragging on non-macOS platforms

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -62,6 +62,8 @@ export default function Header({
   }, []);
 
   const handleMouseDown = async (e: React.MouseEvent<HTMLElement>) => {
+    // Window dragging is only supported on macOS with titleBarStyle: "Overlay"
+    if (!isMacOS) return;
     if (e.buttons === 1) {
       try {
         const { getCurrentWindow } = await import("@tauri-apps/api/window");


### PR DESCRIPTION
The handleMouseDown function in Header.tsx was calling startDragging() on all platforms, but titleBarStyle: "Overlay" is only supported on macOS. On Linux, this was blocking all click events in the header area, making buttons (Open File, Bookshelf, Zoom, Two-Column, etc.) unusable.